### PR TITLE
fix: find usage-tui in ~/.local/bin when GNOME Shell PATH omits it

### DIFF
--- a/extension/extension.js
+++ b/extension/extension.js
@@ -11,10 +11,9 @@ import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 const REFRESH_INTERVAL_SECONDS = 300;
 const ENV_FILE_PATH = GLib.get_home_dir() + '/.config/usage-tui/env';
 
-/**
- * Resolve the usage-tui binary path.
- * Checks PATH first, then USAGE_TUI_PATH from the env file.
- */
+// GLib.find_program_in_path uses GNOME Shell's PATH, which typically omits
+// ~/.local/bin — the standard `pip install --user` destination. Check common
+// locations explicitly before falling back.
 function _getUsageTuiPath() {
     let found = GLib.find_program_in_path('usage-tui');
     if (found)
@@ -23,6 +22,15 @@ function _getUsageTuiPath() {
     let env = _loadEnvFromFile();
     if (env.USAGE_TUI_PATH)
         return env.USAGE_TUI_PATH;
+
+    const fallbacks = [
+        GLib.get_home_dir() + '/.local/bin/usage-tui',
+        '/usr/local/bin/usage-tui',
+    ];
+    for (let path of fallbacks) {
+        if (GLib.file_test(path, GLib.FileTest.IS_EXECUTABLE))
+            return path;
+    }
 
     return 'usage-tui';
 }


### PR DESCRIPTION
## Problem

`GLib.find_program_in_path` searches GNOME Shell's process PATH, which typically does **not** include `~/.local/bin`. That's the directory where `pip install --user` places scripts — exactly what the installation instructions tell users to run. Every fresh install hits the `Err` panel state as a result.

The `USAGE_TUI_PATH` escape hatch in `~/.config/usage-tui/env` works but is undocumented and requires manual intervention that most users won't know to do.

## Fix

After `find_program_in_path` and `USAGE_TUI_PATH` both come up empty, explicitly probe `~/.local/bin/usage-tui` and `/usr/local/bin/usage-tui` using `GLib.file_test` before falling back to the bare `'usage-tui'` string. This makes the extension work out of the box for the documented install path.

## Testing

Verified locally: removed `~/.local/bin` from the session PATH, confirmed the extension previously showed `Err`, applied this patch, and confirmed it resolved correctly to the binary and displayed usage data.