### PR TITLE
feat: add GNOME Shell 49 to supported versions

### DIFF
--- a/extension/metadata.json
+++ b/extension/metadata.json
@@ -3,7 +3,7 @@
   "name": "Usage TUI Monitor",
   "description": "Display AI service usage metrics (Claude, OpenAI, OpenRouter, Copilot, Codex) in the GNOME top panel. Track your API quotas and credits at a glance.",
   "version": 3,
-  "shell-version": ["45", "46", "47", "48"],
+  "shell-version": ["45", "46", "47", "48", "49"],
   "url": "https://github.com/OmegAshEnr01n/GnomeCodexBar",
   "donations": {
     "github": "OmegAshEnr01n"


### PR DESCRIPTION
Adds `"49"` to the `shell-version` array in `metadata.json` so the extension loads on GNOME Shell 49 without requiring a manual metadata patch.