### PR TITLE
feat: add GSettings preferences and 5h utilization panel mode

### DIFF
--- a/extension/extension.js
+++ b/extension/extension.js
@@ -7,9 +7,11 @@ import GObject from 'gi://GObject';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 
 const REFRESH_INTERVAL_SECONDS = 300;
 const ENV_FILE_PATH = GLib.get_home_dir() + '/.config/usage-tui/env';
+const PROVIDER_ABBR = {claude: 'C', openrouter: 'OR', copilot: 'CO', codex: 'CX'};
 
 /**
  * Resolve the usage-tui binary path.
@@ -92,8 +94,12 @@ function _getProgressClass(pct) {
 const UsageTuiIndicator = GObject.registerClass(
 class UsageTuiIndicator extends PanelMenu.Button {
 
-    _init() {
+    _init(extension) {
         super._init(0.0, 'usage-tui Monitor', false);
+
+        this._extension = extension;
+        this._settings = extension.getSettings();
+        this._settingsChangedId = this._settings.connect('changed', () => this._updateUI());
 
         this._timeout = null;
         this._usageData = {};
@@ -192,6 +198,10 @@ class UsageTuiIndicator extends PanelMenu.Button {
             this._openTerminalWithCommand(`${_getUsageTuiPath()} tui`);
         });
         this.menu.addMenuItem(openTuiItem);
+
+        let settingsItem = new PopupMenu.PopupMenuItem('Open Settings');
+        settingsItem.connect('activate', () => this._extension.openPreferences());
+        this.menu.addMenuItem(settingsItem);
 
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
@@ -616,6 +626,27 @@ class UsageTuiIndicator extends PanelMenu.Button {
         }
     }
 
+    _getUtilizationLabel() {
+        const included = this._settings.get_strv('included-providers');
+        const showPrefix = this._settings.get_boolean('show-provider-prefix');
+        let parts = [];
+        for (let name of this._providerOrder) {
+            if (!included.includes(name)) continue;
+            let data = this._usageData[name];
+            if (!data || !data.raw) continue;
+            let pct = null;
+            if (data.raw.five_hour && data.raw.five_hour.utilization != null)
+                pct = data.raw.five_hour.utilization;
+            else if (data.raw.rate_limit?.primary_window?.used_percent != null)
+                pct = data.raw.rate_limit.primary_window.used_percent;
+            if (pct != null) {
+                let abbr = PROVIDER_ABBR[name] ?? name.slice(0, 2).toUpperCase();
+                parts.push(showPrefix ? `${abbr}:${pct.toFixed(0)}%` : `${pct.toFixed(0)}%`);
+            }
+        }
+        return parts.length > 0 ? parts.join(' ') : 'N/A';
+    }
+
     _startAutoRefresh() {
         if (this._timeout)
             GLib.source_remove(this._timeout);
@@ -719,12 +750,21 @@ class UsageTuiIndicator extends PanelMenu.Button {
         if (!this._activeProvider && firstProvider)
             this._switchToProvider(firstProvider);
 
-        if (hasCostData)
-            this._panelLabel.set_text(`$${totalCost.toFixed(2)}`);
-        else if (configuredProviders > 0)
-            this._panelLabel.set_text(`${configuredProviders} active`);
+        if (this._settings.get_boolean('show-panel-icon'))
+            this._icon.show();
         else
+            this._icon.hide();
+
+        const displayMode = this._settings.get_string('display-mode');
+        if (displayMode === 'utilization') {
+            this._panelLabel.set_text(this._getUtilizationLabel());
+        } else if (hasCostData) {
+            this._panelLabel.set_text(`$${totalCost.toFixed(2)}`);
+        } else if (configuredProviders > 0) {
+            this._panelLabel.set_text(`${configuredProviders} active`);
+        } else {
             this._panelLabel.set_text('N/A');
+        }
 
         if (this._lastUpdated) {
             let timeString = this._lastUpdated.toLocaleTimeString('en-US', {
@@ -753,6 +793,11 @@ class UsageTuiIndicator extends PanelMenu.Button {
     }
 
     destroy() {
+        if (this._settingsChangedId) {
+            this._settings.disconnect(this._settingsChangedId);
+            this._settingsChangedId = null;
+        }
+
         if (this._timeout) {
             GLib.source_remove(this._timeout);
             this._timeout = null;
@@ -762,14 +807,10 @@ class UsageTuiIndicator extends PanelMenu.Button {
     }
 });
 
-export default class UsageTuiExtension {
-    constructor() {
-        this._indicator = null;
-    }
-
+export default class UsageTuiExtension extends Extension {
     enable() {
         console.debug('usage-tui: Enabling extension');
-        this._indicator = new UsageTuiIndicator();
+        this._indicator = new UsageTuiIndicator(this);
         Main.panel.addToStatusArea('usage-tui', this._indicator, 0, 'right');
     }
 

--- a/extension/prefs.js
+++ b/extension/prefs.js
@@ -1,0 +1,82 @@
+import Adw from 'gi://Adw';
+import Gtk from 'gi://Gtk';
+import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+
+const PROVIDERS = ['claude', 'openrouter', 'copilot', 'codex'];
+const DISPLAY_MODES = ['cost', 'utilization'];
+const DISPLAY_MODE_LABELS = ['Cost ($)', '5h Utilization (%)'];
+
+export default class UsageTuiPreferences extends ExtensionPreferences {
+    fillPreferencesWindow(window) {
+        const settings = this.getSettings();
+
+        const page = new Adw.PreferencesPage({
+            title: 'General',
+            icon_name: 'preferences-system-symbolic',
+        });
+        window.add(page);
+
+        const displayGroup = new Adw.PreferencesGroup({title: 'Panel Display'});
+        page.add(displayGroup);
+
+        const modeModel = new Gtk.StringList();
+        for (const label of DISPLAY_MODE_LABELS)
+            modeModel.append(label);
+
+        const modeRow = new Adw.ComboRow({
+            title: 'Display mode',
+            subtitle: 'What to show in the top bar',
+            model: modeModel,
+        });
+
+        const currentMode = settings.get_string('display-mode');
+        modeRow.selected = Math.max(0, DISPLAY_MODES.indexOf(currentMode));
+
+        modeRow.connect('notify::selected', () => {
+            settings.set_string('display-mode', DISPLAY_MODES[modeRow.selected] ?? 'cost');
+        });
+
+        displayGroup.add(modeRow);
+
+        const iconRow = new Adw.SwitchRow({
+            title: 'Show panel icon',
+            subtitle: 'Show the monitor icon to the left of the panel label',
+        });
+        iconRow.active = settings.get_boolean('show-panel-icon');
+        iconRow.connect('notify::active', () => {
+            settings.set_boolean('show-panel-icon', iconRow.active);
+        });
+        displayGroup.add(iconRow);
+
+        const prefixRow = new Adw.SwitchRow({
+            title: 'Show provider prefixes',
+            subtitle: 'Show C:, CX: etc. before percentages in the panel label',
+        });
+        prefixRow.active = settings.get_boolean('show-provider-prefix');
+        prefixRow.connect('notify::active', () => {
+            settings.set_boolean('show-provider-prefix', prefixRow.active);
+        });
+        displayGroup.add(prefixRow);
+
+        const providersGroup = new Adw.PreferencesGroup({
+            title: 'Included Providers',
+            description: 'Which providers to include in the panel label',
+        });
+        page.add(providersGroup);
+
+        for (const provider of PROVIDERS) {
+            const row = new Adw.SwitchRow({title: provider});
+            row.active = settings.get_strv('included-providers').includes(provider);
+
+            row.connect('notify::active', () => {
+                const current = settings.get_strv('included-providers');
+                if (row.active && !current.includes(provider))
+                    settings.set_strv('included-providers', [...current, provider]);
+                else if (!row.active)
+                    settings.set_strv('included-providers', current.filter(p => p !== provider));
+            });
+
+            providersGroup.add(row);
+        }
+    }
+}

--- a/extension/schemas/org.gnome.shell.extensions.usage-tui.gschema.xml
+++ b/extension/schemas/org.gnome.shell.extensions.usage-tui.gschema.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <schema id="org.gnome.shell.extensions.usage-tui"
+          path="/org/gnome/shell/extensions/usage-tui/">
+    <key name="display-mode" type="s">
+      <default>'cost'</default>
+      <summary>Panel display mode</summary>
+    </key>
+    <key name="included-providers" type="as">
+      <default>['claude', 'openrouter', 'copilot', 'codex']</default>
+      <summary>Providers shown in the panel label</summary>
+    </key>
+    <key name="show-panel-icon" type="b">
+      <default>true</default>
+      <summary>Show icon in panel button</summary>
+    </key>
+    <key name="show-provider-prefix" type="b">
+      <default>true</default>
+      <summary>Show provider prefix (C:, CX:) before percentages in panel label</summary>
+    </key>
+  </schema>
+</schemalist>


### PR DESCRIPTION
## Summary

- **GSettings schema** (`schemas/org.gnome.shell.extensions.usage-tui.gschema.xml`) with four keys: `display-mode`, `included-providers`, `show-panel-icon`, `show-provider-prefix`
- **`prefs.js`** — Adwaita preferences window (opened via *Open Settings* in the panel menu) with two groups:
  - *Panel Display*: display-mode combo (Cost / 5h Utilization), icon toggle, provider-prefix toggle
  - *Included Providers*: per-provider switches that filter which providers appear in the utilization label
- **`extension.js`** changes:
  - `UsageTuiExtension` now extends the `Extension` base class so `getSettings()` / `openPreferences()` work
  - `UsageTuiIndicator._init()` accepts the extension, loads settings, and reconnects UI on `changed`
  - `_updateUI()` reads `display-mode` to show either `$0.04` (cost) or `C:12% CX:49%` (utilization)
  - `show-panel-icon` toggles the monitor icon; `show-provider-prefix` toggles the `C:`/`CX:` prefixes
  - *Open Settings* menu item added between *Open usage-tui TUI* and the last-updated footer

## Test plan

- [ ] Compile schema: `glib-compile-schemas extension/schemas/`
- [ ] Install extension and open *Open Settings* from the panel popup
- [ ] Toggle display mode → panel label switches between cost and utilization
- [ ] Toggle *Show panel icon* → icon appears/disappears without restart
- [ ] Toggle *Show provider prefixes* → prefixes appear/disappear in utilization mode
- [ ] Disable a provider in *Included Providers* → it's excluded from the utilization label
- [ ] Verify `destroy()` cleans up the settings signal (no warnings on disable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)