### PR TITLE
fix: keep last known panel label during background refresh

### DIFF
--- a/extension/extension.js
+++ b/extension/extension.js
@@ -631,8 +631,6 @@ class UsageTuiIndicator extends PanelMenu.Button {
     }
 
     _refreshData() {
-        this._panelLabel.set_text('...');
-
         try {
             let launcher = new Gio.SubprocessLauncher({
                 flags: Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE,


### PR DESCRIPTION
## Problem

Every time `_refreshData()` was called, it immediately set the panel label to `...` before the async subprocess finished. This caused a visible flicker on every refresh cycle (every 5 minutes, or on manual refresh).

## Fix

Remove the eager `set_text('...')` at the start of `_refreshData()`. The label already initialises to `'...'` in `_buildPanelButton()` on first load, so the initial state is unchanged. On subsequent refreshes the previous value stays visible until the subprocess completes and `_updateUI()` sets the new value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)