### PR TITLE
Add Antigravity quota monitoring

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -2,6 +2,21 @@
 
 ## Extension Versions
 
+### v1.0.3 (2026-03-29) - Extension version 5
+**Fixed**
+- Refactored `extension.js` to correctly display native Pro and Flash dual-progress bars for Google Gemini, omitting incorrect 5h/7d mappings logic entirely.
+
+**Technical Changes**
+- Extension metadata version: 5
+
+### v1.0.2 (2026-03-29) - Extension version 4
+**Added**
+- Added Gemini support!
+- Displays dynamic scaled quota percentage correctly for Gemini tokens via `usage_tui`
+
+**Technical Changes**
+- Extension metadata version: 4
+
 ### v1.0.1 (2026-02-15) - Extension version 3
 **Fixed**
 - Copilot provider now displays actual credit numbers (e.g., 162/1500) instead of percentages (10.8/100)
@@ -24,6 +39,15 @@
 ---
 
 ## usage-tui Python Package Versions
+
+### v0.1.2 (2026-03-29)
+**Added**
+- Support for Gemini quotas and usage tracking mapping local daemon logs
+- Request tally mapped from Gemini model context counts correctly combining Pro and Flash requests
+- Dual-bar unified tab rendering both Google Gemini Pro and Gemini Flash inside a single view
+
+**Fixed**
+- Renamed `ClaudeOAuthProvider` to `ClaudeProvider` for consistency across OpenCode providers
 
 ### v0.1.1 (2026-02-15)
 **Fixed**

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -101,7 +101,7 @@ class UsageTuiIndicator extends PanelMenu.Button {
         this._providerTabs = {};
         this._lastUpdated = null;
         this._activeProvider = null;
-        this._providerOrder = ['claude', 'openrouter', 'copilot', 'codex'];
+        this._providerOrder = ['claude', 'gemini', 'openrouter', 'copilot', 'codex'];
 
         this._buildPanelButton();
         this._buildPopupMenu();
@@ -209,7 +209,7 @@ class UsageTuiIndicator extends PanelMenu.Button {
         });
 
         let tabLabel = new St.Label({
-            text: providerName.toUpperCase(),
+            text: providerName === 'gemini' ? 'ANTIGRAVITY' : providerName.toUpperCase(),
             style_class: `usage-tui-tab-label usage-tui-tab-label-${providerName}`,
         });
 
@@ -355,9 +355,17 @@ class UsageTuiIndicator extends PanelMenu.Button {
 
         let fiveHourBar = createWindowBar('5h');
         let sevenDayBar = createWindowBar('7d');
+        let proBar = createWindowBar('Pro');
+        let flashBar = createWindowBar('Flash');
+        let claudeBar = createWindowBar('Claude');
+        let openSourceBar = createWindowBar('GPT-OSS');
 
         windowBars.add_child(fiveHourBar.container);
         windowBars.add_child(sevenDayBar.container);
+        windowBars.add_child(proBar.container);
+        windowBars.add_child(flashBar.container);
+        windowBars.add_child(claudeBar.container);
+        windowBars.add_child(openSourceBar.container);
         windowBars.hide();
 
         container.add_child(windowBars);
@@ -393,6 +401,10 @@ class UsageTuiIndicator extends PanelMenu.Button {
             windowBars,
             fiveHourBar,
             sevenDayBar,
+            proBar,
+            flashBar,
+            claudeBar,
+            openSourceBar,
             costLabel,
             byokLabel,
             requestsLabel,
@@ -421,6 +433,10 @@ class UsageTuiIndicator extends PanelMenu.Button {
             card.windowBars.hide();
             card.fiveHourBar.container.hide();
             card.sevenDayBar.container.hide();
+            card.proBar.container.hide();
+            card.flashBar.container.hide();
+            card.claudeBar.container.hide();
+            card.openSourceBar.container.hide();
             card.progressContainer.show();
             return;
         }
@@ -438,6 +454,15 @@ class UsageTuiIndicator extends PanelMenu.Button {
             : (raw.rate_limit && raw.rate_limit.secondary_window && raw.rate_limit.secondary_window.used_percent !== null && raw.rate_limit.secondary_window.used_percent !== undefined
                 ? raw.rate_limit.secondary_window.used_percent
                 : null);
+
+        const proUtil = raw.gemini_pro && raw.gemini_pro.utilization !== null && raw.gemini_pro.utilization !== undefined
+            ? raw.gemini_pro.utilization : null;
+        const flashUtil = raw.gemini_flash && raw.gemini_flash.utilization !== null && raw.gemini_flash.utilization !== undefined
+            ? raw.gemini_flash.utilization : null;
+        const claudeUtil = raw.claude && raw.claude.utilization !== null && raw.claude.utilization !== undefined
+            ? raw.claude.utilization : null;
+        const openSourceUtil = raw.gpt_oss && raw.gpt_oss.utilization !== null && raw.gpt_oss.utilization !== undefined
+            ? raw.gpt_oss.utilization : null;
 
         const updateWindowBar = (bar, pct, resetTime, useDays) => {
             bar.pctLabel.text = `${pct.toFixed(1)}%`;
@@ -484,6 +509,10 @@ class UsageTuiIndicator extends PanelMenu.Button {
 
         let fiveHourReset = null;
         let sevenDayReset = null;
+        let proReset = null;
+        let flashReset = null;
+        let claudeReset = null;
+        let openSourceReset = null;
 
         if (raw.five_hour && raw.five_hour.resets_at)
             fiveHourReset = raw.five_hour.resets_at;
@@ -494,6 +523,15 @@ class UsageTuiIndicator extends PanelMenu.Button {
             fiveHourReset = raw.rate_limit.primary_window.reset_at;
         if (raw.rate_limit && raw.rate_limit.secondary_window && raw.rate_limit.secondary_window.reset_at)
             sevenDayReset = raw.rate_limit.secondary_window.reset_at;
+
+        if (raw.gemini_pro && raw.gemini_pro.reset_time)
+            proReset = raw.gemini_pro.reset_time;
+        if (raw.gemini_flash && raw.gemini_flash.reset_time)
+            flashReset = raw.gemini_flash.reset_time;
+        if (raw.claude && raw.claude.reset_time)
+            claudeReset = raw.claude.reset_time;
+        if (raw.gpt_oss && raw.gpt_oss.reset_time)
+            openSourceReset = raw.gpt_oss.reset_time;
 
         let hasWindowBars = false;
         if (fiveHourUtil !== null) {
@@ -512,6 +550,42 @@ class UsageTuiIndicator extends PanelMenu.Button {
         } else {
             card._barData.sevenDay = null;
             card.sevenDayBar.container.hide();
+        }
+
+        if (proUtil !== null) {
+            card._barData.pro = {pct: proUtil, resetTime: proReset};
+            updateWindowBar(card.proBar, proUtil, proReset, false);
+            hasWindowBars = true;
+        } else {
+            card._barData.pro = null;
+            card.proBar.container.hide();
+        }
+
+        if (flashUtil !== null) {
+            card._barData.flash = {pct: flashUtil, resetTime: flashReset};
+            updateWindowBar(card.flashBar, flashUtil, flashReset, false);
+            hasWindowBars = true;
+        } else {
+            card._barData.flash = null;
+            card.flashBar.container.hide();
+        }
+
+        if (openSourceUtil !== null) {
+            card._barData.openSource = {pct: openSourceUtil, resetTime: openSourceReset};
+            updateWindowBar(card.openSourceBar, openSourceUtil, openSourceReset, false);
+            hasWindowBars = true;
+        } else {
+            card._barData.openSource = null;
+            card.openSourceBar.container.hide();
+        }
+
+        if (claudeUtil !== null) {
+            card._barData.claude = {pct: claudeUtil, resetTime: claudeReset};
+            updateWindowBar(card.claudeBar, claudeUtil, claudeReset, false);
+            hasWindowBars = true;
+        } else {
+            card._barData.claude = null;
+            card.claudeBar.container.hide();
         }
 
         if (hasWindowBars) {

--- a/extension/metadata.json
+++ b/extension/metadata.json
@@ -1,9 +1,9 @@
 {
   "uuid": "usage-tui@gnome.codexbar",
   "name": "Usage TUI Monitor",
-  "description": "Display AI service usage metrics (Claude, OpenAI, OpenRouter, Copilot, Codex) in the GNOME top panel. Track your API quotas and credits at a glance.",
-  "version": 3,
-  "shell-version": ["45", "46", "47", "48"],
+  "description": "Display AI service usage metrics (Claude, OpenAI, OpenRouter, Copilot, Codex, Gemini) in the GNOME top panel. Track your API quotas and credits at a glance.",
+  "version": 5,
+  "shell-version": ["45", "46", "47", "48", "49", "50"],
   "url": "https://github.com/OmegAshEnr01n/GnomeCodexBar",
   "donations": {
     "github": "OmegAshEnr01n"

--- a/extension/stylesheet.css
+++ b/extension/stylesheet.css
@@ -38,6 +38,10 @@
     border-bottom: 2px solid #D4A574;
 }
 
+.usage-tui-tab-active-gemini {
+    border-bottom: 2px solid #4285F4;
+}
+
 .usage-tui-tab-active-openai {
     border-bottom: 2px solid #74AA9C;
 }
@@ -63,6 +67,10 @@
 
 .usage-tui-tab-label-claude {
     color: #D4A574;
+}
+
+.usage-tui-tab-label-gemini {
+    color: #4285F4;
 }
 
 .usage-tui-tab-label-openai {
@@ -102,6 +110,10 @@
 
 .usage-tui-provider-claude {
     border-left: 3px solid #D4A574;
+}
+
+.usage-tui-provider-gemini {
+    border-left: 3px solid #4285F4;
 }
 
 .usage-tui-provider-openai {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "usage-tui"
-version = "0.1.1"
+version = "0.1.2"
 description = "Multi-provider usage metrics TUI for Claude, OpenAI, and GitHub Copilot"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_gemini.py
+++ b/tests/test_gemini.py
@@ -1,0 +1,20 @@
+import pytest
+import anyio
+from usage_tui.providers.gemini import GeminiProvider
+from usage_tui.providers.base import ProviderName, WindowPeriod
+
+def test_gemini_init():
+    provider = GeminiProvider()
+    assert provider.name == ProviderName.GEMINI
+    assert provider.is_configured() is True
+
+@pytest.mark.anyio
+async def test_gemini_fetch():
+    provider = GeminiProvider()
+    result = await provider.fetch(WindowPeriod.HOUR_5)
+    assert result.provider == ProviderName.GEMINI
+    assert result.metrics.limit == 100.0
+
+@pytest.fixture
+def anyio_backend():
+    return 'asyncio'

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,20 @@
+import pytest
+from usage_tui.tui import UsageTUI
+
+@pytest.mark.asyncio
+async def test_tui_startup():
+    """
+    Test that the TUI can initialize, mount, and complete its first data fetch
+    render cycle without throwing uncaught exceptions (like UnboundLocalError).
+    """
+    app = UsageTUI()
+    
+    # Textual's run_test() simulates a headless terminal and allows
+    # us to wait for background tasks and UI updates to settle.
+    async with app.run_test() as pilot:
+        # Wait enough time for the initial async data fetch and watch_result updates to trigger
+        await pilot.pause(1.0)
+        
+        # If any exception occurred in the UI thread or message handlers,
+        # it would cause the test context to fail or the app to crash.
+        assert app.is_running

--- a/usage_tui/cache.py
+++ b/usage_tui/cache.py
@@ -38,6 +38,7 @@ class ResultCache:
     DEFAULT_TTL = 120  # 2 minutes
     PROVIDER_TTLS = {
         ProviderName.CLAUDE: 60,  # 1 minute - quota changes quickly
+        ProviderName.GEMINI: 60,  # 1 minute - quota changes quickly
         ProviderName.OPENAI: 180,  # 3 minutes - usage data is historical
         ProviderName.OPENROUTER: 180,  # 3 minutes - credits update periodically
         ProviderName.COPILOT: 300,  # 5 minutes - reports are slow to update

--- a/usage_tui/cli.py
+++ b/usage_tui/cli.py
@@ -9,11 +9,12 @@ from click.core import ParameterSource
 
 from usage_tui.config import config
 from usage_tui.providers import (
-    ClaudeOAuthProvider,
+    ClaudeProvider,
     OpenAIUsageProvider,
     OpenRouterUsageProvider,
     CopilotProvider,
     CodexProvider,
+    GeminiProvider,
 )
 from usage_tui.providers.base import BaseProvider, ProviderError, ProviderName, WindowPeriod
 
@@ -21,11 +22,12 @@ from usage_tui.providers.base import BaseProvider, ProviderError, ProviderName, 
 def get_providers() -> dict[ProviderName, BaseProvider]:
     """Get all available providers."""
     return {
-        ProviderName.CLAUDE: ClaudeOAuthProvider(),
+        ProviderName.CLAUDE: ClaudeProvider(),
         ProviderName.OPENAI: OpenAIUsageProvider(),
         ProviderName.OPENROUTER: OpenRouterUsageProvider(),
         ProviderName.COPILOT: CopilotProvider(),
         ProviderName.CODEX: CodexProvider(),
+        ProviderName.GEMINI: GeminiProvider(),
     }
 
 
@@ -74,7 +76,7 @@ def main() -> None:
     "--provider",
     "-p",
     default="all",
-    help="Provider to query (claude, openai, openrouter, copilot, codex, all)",
+    help="Provider to query (claude, openai, openrouter, copilot, codex, gemini, all)",
 )
 @click.option(
     "--window",
@@ -139,7 +141,7 @@ def show(provider: str, window: str, output_json: bool) -> None:
 
 def _print_result(name: ProviderName, result, label: str | None = None) -> None:
     """Print a formatted result."""
-    title = name.value.upper()
+    title = "ANTIGRAVITY" if name is ProviderName.GEMINI else name.value.upper()
     if label:
         title = f"{title} ({label})"
     click.echo(f"\n{click.style(title, bold=True)}")
@@ -151,8 +153,16 @@ def _print_result(name: ProviderName, result, label: str | None = None) -> None:
 
     m = result.metrics
 
-    # Usage percentage (Claude)
-    if m.usage_percent is not None:
+    # Usage percentage (Claude, Gemini, etc)
+    if result.raw and "gemini_pro" in result.raw and "gemini_flash" in result.raw:
+        for key, name_label in [("gemini_pro", "Pro"), ("gemini_flash", "Flash"), ("claude", "Claude"), ("gpt_oss", "GPT-OSS")]:
+            if key not in result.raw:
+                continue
+            pct = result.raw[key]["utilization"]
+            color = "green" if pct < 50 else ("yellow" if pct < 80 else "red")
+            bar = _progress_bar(pct)
+            click.echo(f"{name_label:8} {bar} {click.style(f'{pct:.1f}%', fg=color)}")
+    elif m.usage_percent is not None:
         pct = m.usage_percent
         color = "green" if pct < 50 else ("yellow" if pct < 80 else "red")
         bar = _progress_bar(pct)

--- a/usage_tui/config.py
+++ b/usage_tui/config.py
@@ -76,6 +76,7 @@ class Config:
         ProviderName.OPENROUTER: "OPENROUTER_API_KEY",
         ProviderName.COPILOT: "GITHUB_TOKEN",
         ProviderName.CODEX: "CODEX_ACCESS_TOKEN",
+        ProviderName.GEMINI: "ANTIGRAVITY_ACCOUNTS_PATH",
     }
 
     # Provider descriptions
@@ -109,6 +110,12 @@ class Config:
             "description": "OpenAI Codex usage via ChatGPT backend",
             "official": False,
             "note": "Reads credentials from ~/.codex/auth.json",
+        },
+        ProviderName.GEMINI: {
+            "name": "Google Gemini",
+            "description": "Google Gemini (antigravity) quota",
+            "official": False,
+            "note": "Reads credentials from ~/.config/opencode/antigravity-accounts.json",
         },
     }
 
@@ -157,19 +164,21 @@ class Config:
         """
         # Import providers lazily to avoid circular imports
         from usage_tui.providers import (
-            ClaudeOAuthProvider,
+            ClaudeProvider,
             OpenAIUsageProvider,
             OpenRouterUsageProvider,
             CopilotProvider,
             CodexProvider,
+            GeminiProvider,
         )
 
         provider_map = {
-            ProviderName.CLAUDE: ClaudeOAuthProvider,
+            ProviderName.CLAUDE: ClaudeProvider,
             ProviderName.OPENAI: OpenAIUsageProvider,
             ProviderName.OPENROUTER: OpenRouterUsageProvider,
             ProviderName.COPILOT: CopilotProvider,
             ProviderName.CODEX: CodexProvider,
+            ProviderName.GEMINI: GeminiProvider,
         }
 
         provider_class = provider_map.get(provider)

--- a/usage_tui/providers/__init__.py
+++ b/usage_tui/providers/__init__.py
@@ -1,19 +1,21 @@
 """Provider implementations for usage metrics."""
 
 from usage_tui.providers.base import BaseProvider, UsageMetrics, ProviderResult
-from usage_tui.providers.claude_oauth import ClaudeOAuthProvider
+from usage_tui.providers.claude_oauth import ClaudeProvider
 from usage_tui.providers.openai_usage import OpenAIUsageProvider
 from usage_tui.providers.openrouter import OpenRouterUsageProvider
 from usage_tui.providers.copilot import CopilotProvider
 from usage_tui.providers.codex import CodexProvider
+from usage_tui.providers.gemini import GeminiProvider
 
 __all__ = [
     "BaseProvider",
     "UsageMetrics",
     "ProviderResult",
-    "ClaudeOAuthProvider",
+    "ClaudeProvider",
     "OpenAIUsageProvider",
     "OpenRouterUsageProvider",
     "CopilotProvider",
     "CodexProvider",
+    "GeminiProvider",
 ]

--- a/usage_tui/providers/base.py
+++ b/usage_tui/providers/base.py
@@ -24,6 +24,7 @@ class ProviderName(str, Enum):
     OPENROUTER = "openrouter"
     COPILOT = "copilot"
     CODEX = "codex"
+    GEMINI = "gemini"
 
 
 class UsageMetrics(BaseModel):

--- a/usage_tui/providers/claude_oauth.py
+++ b/usage_tui/providers/claude_oauth.py
@@ -17,7 +17,7 @@ from usage_tui.providers.base import (
 )
 
 
-class ClaudeOAuthProvider(BaseProvider):
+class ClaudeProvider(BaseProvider):
     """
     Provider for Claude Code OAuth usage metrics.
 

--- a/usage_tui/providers/gemini.py
+++ b/usage_tui/providers/gemini.py
@@ -1,0 +1,157 @@
+import datetime
+import json
+import re
+from pathlib import Path
+import httpx
+
+from usage_tui.providers.base import BaseProvider, UsageMetrics, ProviderResult, ProviderName, WindowPeriod
+
+OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token"
+QUOTA_URL = "https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:fetchAvailableModels"
+LOAD_URL = "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist"
+class GeminiProvider(BaseProvider):
+    name = ProviderName.GEMINI
+
+    def is_configured(self) -> bool:
+        return self._get_refresh_token() is not None
+
+    def get_config_help(self) -> str:
+        return "Log in with the Antigravity/OpenCode Google account"
+
+    def _get_account(self) -> dict | None:
+        paths = [
+            Path.home() / ".config" / "opencode" / "antigravity-accounts.json",
+            Path.home() / ".local" / "share" / "opencode" / "antigravity-accounts.json",
+        ]
+        for p in paths:
+            if not p.exists():
+                continue
+            with open(p) as f:
+                data = json.load(f)
+            accounts = data.get("accounts", [])
+            if accounts:
+                return accounts[0]
+        return None
+
+    def _get_refresh_token(self) -> str | None:
+        account = self._get_account()
+        return account.get("refreshToken") if account else None
+
+    @staticmethod
+    def _get_oauth_client() -> tuple[str, str]:
+        """Read the OAuth client managed by the installed OpenCode plugin."""
+        candidates = [
+            Path.home() / ".cache" / "opencode" / "node_modules" / "opencode-antigravity-auth" / "dist" / "src" / "constants.js",
+            Path.home() / ".cache" / "opencode" / "packages" / "opencode-antigravity-auth@latest" / "node_modules" / "opencode-antigravity-auth" / "dist" / "src" / "constants.js",
+        ]
+        for path in candidates:
+            if not path.exists():
+                continue
+            text = path.read_text()
+            client_id = re.search(r'ANTIGRAVITY_CLIENT_ID = "([^"]+)"', text)
+            client_secret = re.search(r'ANTIGRAVITY_CLIENT_SECRET = "([^"]+)"', text)
+            if client_id and client_secret:
+                return client_id.group(1), client_secret.group(1)
+        raise ValueError("OpenCode Antigravity auth plugin is not installed")
+
+    @staticmethod
+    def _quota_to_raw(quota_data: dict) -> dict:
+        """Normalize either a live API response or Antigravity's cached quota."""
+        quotas_by_model = {
+            entry.get("modelId", ""): entry
+            for entry in quota_data.get("quotas", [])
+        }
+        if not quotas_by_model and quota_data.get("models"):
+            quotas_by_model = {
+                f"{model_id} {model.get('displayName', '')}".lower(): model.get("quotaInfo", {})
+                for model_id, model in quota_data["models"].items()
+            }
+        if not quotas_by_model:
+            quotas_by_model = quota_data
+
+        def get_pct(quota: dict) -> float:
+            remaining = quota.get("remainingFraction")
+            return round((1.0 - remaining) * 100, 1) if remaining is not None else 0.0
+
+        def quota_for(*names: str) -> dict:
+            for name in names:
+                if name in quotas_by_model:
+                    return quotas_by_model[name]
+            for model_id, quota in quotas_by_model.items():
+                if any(name in model_id for name in names):
+                    return quota
+            return {}
+
+        pro_q = quota_for("gemini-pro", "gemini-1.5-pro", "pro")
+        flash_q = quota_for("gemini-flash", "gemini-1.5-flash", "flash")
+        claude_q = quota_for("claude")
+        gpt_oss_q = quota_for("gpt-oss", "gpt_oss")
+        return {
+            "gemini_pro": {"utilization": get_pct(pro_q), "reset_time": pro_q.get("resetTime")},
+            "gemini_flash": {"utilization": get_pct(flash_q), "reset_time": flash_q.get("resetTime")},
+            "claude": {"utilization": get_pct(claude_q), "reset_time": claude_q.get("resetTime")},
+            "gpt_oss": {"utilization": get_pct(gpt_oss_q), "reset_time": gpt_oss_q.get("resetTime")},
+        }
+
+    async def _get_access_token(self, refresh_token: str) -> str:
+        client_id, client_secret = self._get_oauth_client()
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(OAUTH_TOKEN_URL, data={
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "refresh_token": refresh_token,
+                "grant_type": "refresh_token",
+            })
+            resp.raise_for_status()
+            return resp.json()["access_token"]
+
+    async def fetch(self, window: WindowPeriod = WindowPeriod.HOUR_5) -> ProviderResult:
+        metrics = UsageMetrics(remaining=0.0, limit=100.0)
+        raw: dict = {}
+
+        try:
+            account = self._get_account()
+            refresh_token = account.get("refreshToken") if account else None
+            if not refresh_token:
+                raise ValueError("No Gemini refresh token found in antigravity-accounts.json")
+
+            access_token = await self._get_access_token(refresh_token)
+            headers = {
+                "Authorization": f"Bearer {access_token}",
+                "Content-Type": "application/json",
+                "User-Agent": "antigravity/1.21.9 linux/amd64",
+                "X-Goog-Api-Client": "google-cloud-sdk vscode_cloudshelleditor/0.1",
+                "Client-Metadata": '{"ideType":"ANTIGRAVITY","platform":"MACOS","pluginType":"GEMINI"}',
+            }
+
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(QUOTA_URL, headers=headers, json={})
+                resp.raise_for_status()
+                quota_data = resp.json()
+
+            raw = self._quota_to_raw(quota_data)
+
+            # Best available reset time for the primary metrics object
+            primary_reset_str = raw["gemini_pro"]["reset_time"] or raw["gemini_flash"]["reset_time"]
+            reset_dt = None
+            if primary_reset_str:
+                reset_dt = datetime.datetime.fromisoformat(primary_reset_str.replace("Z", "+00:00"))
+                now = datetime.datetime.now(datetime.timezone.utc)
+                while reset_dt < now:
+                    reset_dt += datetime.timedelta(days=1)
+
+            metrics = UsageMetrics(
+                remaining=100.0 - raw["gemini_pro"]["utilization"],
+                limit=100.0,
+                reset_at=reset_dt,
+            )
+
+        except Exception as e:
+            return self._make_error_result(window, str(e))
+
+        return ProviderResult(
+            provider=self.name,
+            window=window,
+            metrics=metrics,
+            raw=raw,
+        )

--- a/usage_tui/tui.py
+++ b/usage_tui/tui.py
@@ -24,9 +24,10 @@ from textual.widgets import (
 from usage_tui.cache import ResultCache
 from usage_tui.config import config
 from usage_tui.providers import (
-    ClaudeOAuthProvider,
+    ClaudeProvider,
     CodexProvider,
     CopilotProvider,
+    GeminiProvider,
     OpenAIUsageProvider,
     OpenRouterUsageProvider,
 )
@@ -158,15 +159,46 @@ class ProviderCard(Static):
             return
 
         # Update status line with last update time
-        age = datetime.now(timezone.utc) - result.updated_at.replace(tzinfo=timezone.utc)
+        age = datetime.now(timezone.utc) - result.updated_at.astimezone(timezone.utc)
         age_str = self._format_age(age.total_seconds())
         status_line.update(f"Updated {age_str} ago | Window: {result.window.value}")
 
         # Build metrics display
         metrics = result.metrics
+        raw = result.raw or {}
 
-        # Usage bar for Claude (has limit/remaining)
-        if metrics.usage_percent is not None:
+        # Gemini: render Pro and Flash bars from raw data
+        if "gemini_pro" in raw or "gemini_flash" in raw:
+            for key, label in [("gemini_pro", "Pro"), ("gemini_flash", "Flash"), ("claude", "Claude")]:
+                entry = raw.get(key)
+                if not entry:
+                    continue
+                pct = entry.get("utilization", 0.0)
+                bar = ProgressBar(total=100, show_eta=False)
+                bar.progress = pct
+                metrics_container.mount(Label(label, classes="metric-label"))
+                metrics_container.mount(bar)
+                pct_label = Label(f"{pct:.1f}% used", classes="metric-value")
+                if pct > 80:
+                    pct_label.add_class("warning")
+                if pct > 95:
+                    pct_label.add_class("error")
+                metrics_container.mount(pct_label)
+                reset_time = entry.get("reset_time")
+                if reset_time:
+                    reset_dt = datetime.fromisoformat(reset_time)
+                    delta = reset_dt - datetime.now(timezone.utc)
+                    if delta.total_seconds() > 0:
+                        reset_str = self._format_duration(delta.total_seconds())
+                        metrics_container.mount(
+                            Horizontal(
+                                Label("Resets in:", classes="metric-label"),
+                                Label(reset_str, classes="metric-value"),
+                                classes="metric-row",
+                            )
+                        )
+        elif metrics.usage_percent is not None:
+            # Usage bar for providers with limit/remaining (Claude, Codex, etc.)
             pct = metrics.usage_percent
             bar = ProgressBar(total=100, show_eta=False)
             bar.progress = pct
@@ -366,11 +398,12 @@ class UsageTUI(App):
         super().__init__()
         self.cache = ResultCache()
         self.providers: dict[ProviderName, BaseProvider] = {
-            ProviderName.CLAUDE: ClaudeOAuthProvider(),
+            ProviderName.CLAUDE: ClaudeProvider(),
             ProviderName.OPENAI: OpenAIUsageProvider(),
             ProviderName.OPENROUTER: OpenRouterUsageProvider(),
             ProviderName.COPILOT: CopilotProvider(),
             ProviderName.CODEX: CodexProvider(),
+            ProviderName.GEMINI: GeminiProvider(),
         }
         self.results: dict[ProviderName, ProviderResult | None] = {}
 
@@ -391,6 +424,7 @@ class UsageTUI(App):
                         ProviderCard(ProviderName.OPENROUTER, id="card-openrouter"),
                         ProviderCard(ProviderName.COPILOT, id="card-copilot"),
                         ProviderCard(ProviderName.CODEX, id="card-codex"),
+                        ProviderCard(ProviderName.GEMINI, id="card-gemini"),
                         id="cards-container",
                     )
                 with TabPane("Raw JSON", id="json-tab"):


### PR DESCRIPTION
## What changed

Adds live Antigravity quota monitoring to usage-tui and the GNOME panel, including Gemini Pro, Gemini Flash, Claude, and GPT-OSS pools.

## Why

The prior provider was tied to stale local authentication and could report incorrect quota values. It now follows the locally installed OpenCode Antigravity auth plugin at runtime.

## Validation

- ...                                                                      [100%]
=============================== warnings summary ===============================
tests/test_gemini.py::test_gemini_fetch
  /home/thunder/.pyenv/versions/3.14.1/lib/python3.14/site-packages/pydantic/main.py:263: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
3 passed, 1 warning in 1.90s
- Verified current Antigravity quota pools through OpenCode
- Verified 
ANTIGRAVITY
----------------------------------------
Pro      [#-------------------] 8.1%
Flash    [#-------------------] 8.1%
Claude   [--------------------] 0.0%
GPT-OSS  [--------------------] 0.0%
Resets:   3h 16m